### PR TITLE
Feat/django 42 compatible

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Unreleased
 * Python 3.10 support added
 * Python 3.7 support removed
 * Django 4.2 support added
-* Djanjo 2.2 support removed
+* Django 2.2 support removed
 
 1.8.3 (2024-03-06)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ====================
-djangocms-navigation
+djangocms-navigation 
 ====================
 
 Installation

--- a/djangocms_navigation/admin.py
+++ b/djangocms_navigation/admin.py
@@ -499,7 +499,10 @@ class MenuItemAdmin(TreeAdmin):
         """
         if is_preview_url(request=request):
             return "admin/djangocms_navigation/menuitem/preview.html"
-        return "admin/djangocms_navigation/menuitem/change_list.html"
+        elif TREEBEARD_4_5:
+            return "admin/djangocms_navigation/menuitem/change_list.html"
+        else:
+            return "admin/djangocms_navigation/menuitem/tree_change_list.html"
 
     def changelist_view(self, request, menu_content_id=None, extra_context=None):
         self.change_list_template = self.get_changelist_template(request=request)
@@ -519,7 +522,6 @@ class MenuItemAdmin(TreeAdmin):
                     return HttpResponseRedirect(version_list_url(menu_content))
             extra_context["title"] = "Edit Menu: {}".format(menu_content.__str__())
             extra_context["menu_content"] = menu_content
-            extra_context["treebeard_4_5"] = TREEBEARD_4_5
             extra_context["versioning_enabled_for_nav"] = self._versioning_enabled
 
         return super().changelist_view(request, extra_context)

--- a/djangocms_navigation/admin.py
+++ b/djangocms_navigation/admin.py
@@ -26,6 +26,7 @@ from djangocms_versioning.helpers import get_admin_url, version_list_url
 from djangocms_versioning.models import Version
 from treebeard.admin import TreeAdmin
 
+from .compat import TREEBEARD_4_5
 from .conf import TREE_MAX_RESULT_PER_PAGE_COUNT
 from .filters import LanguageFilter
 from .forms import MenuContentForm, MenuItemForm
@@ -518,6 +519,7 @@ class MenuItemAdmin(TreeAdmin):
                     return HttpResponseRedirect(version_list_url(menu_content))
             extra_context["title"] = "Edit Menu: {}".format(menu_content.__str__())
             extra_context["menu_content"] = menu_content
+            extra_context["treebeard_4_5"] = TREEBEARD_4_5
             extra_context["versioning_enabled_for_nav"] = self._versioning_enabled
 
         return super().changelist_view(request, extra_context)

--- a/djangocms_navigation/compat.py
+++ b/djangocms_navigation/compat.py
@@ -1,6 +1,5 @@
-import django
-
 from packaging.version import Version
+from treebeard import __version__ as treebeard_version
 
 
-DJANGO_4_2 = Version(django.get_version()) >= Version('4.2')
+TREEBEARD_4_5 = Version(treebeard_version) < Version('4.6')

--- a/djangocms_navigation/static/djangocms_navigation/js/navigation-tree-admin.js
+++ b/djangocms_navigation/static/djangocms_navigation/js/navigation-tree-admin.js
@@ -14,6 +14,26 @@ Original code found in treebeard-admin.js
 
     const EXPANDED_SESSION_KEY = 'expanded-';
 
+    // Add jQuery util for disabling selection
+    // Originally taken from jquery-ui (where it is deprecated)
+    // https://api.jqueryui.com/disableSelection/
+    if($.fn.disableSelection == undefined) {
+        $.fn.extend( {
+            disableSelection: ( function() {
+                var eventType = "onselectstart" in document.createElement( "div" ) ? "selectstart" : "mousedown";
+                return function() {
+                    return this.on( eventType + ".ui-disableSelection", function( event ) {
+                        event.preventDefault();
+                    } );
+                };
+            } )(),
+    
+            enableSelection: function() {
+                return this.off( ".ui-disableSelection" );
+            }
+        } );
+    }
+
     // This is the basic Node class, which handles UI tree operations for each 'row'
     var Node = function (elem) {
         var $elem = $(elem);
@@ -146,7 +166,7 @@ Original code found in treebeard-admin.js
                 if (document.cookie && document.cookie != '') {
                     var cookies = document.cookie.split(';');
                     for (var i = 0; i < cookies.length; i++) {
-                        var cookie = jQuery.trim(cookies[i]);
+                        var cookie = $.trim(cookies[i]);
                         // Does this cookie string begin with the name we want?
                         if (cookie.substring(0, name.length + 1) == (name + '=')) {
                             cookieValue = decodeURIComponent(cookie.substring(name.length + 1));

--- a/djangocms_navigation/templates/admin/djangocms_navigation/menuitem/change_list.html
+++ b/djangocms_navigation/templates/admin/djangocms_navigation/menuitem/change_list.html
@@ -7,6 +7,15 @@
 <link rel="stylesheet" type="text/css" href="{% static 'djangocms_navigation/css/navigation_admin_overrides.css' %}"/>
 {% endblock %}
 
+{% block extrahead %}
+    {% if not treebeard_4_5 %}
+    <script src="{% url 'admin:jsi18n' %}"></script>
+    <script data-csrftoken="{{ csrf_token }}" src="{% static 'djangocms_navigation/js/navigation-tree-admin.js' %}"></script>
+    {% else %}
+    {{ block.super }}
+    {% endif %}
+{% endblock %}
+
 {% block object-tools-items %}
 <li>
     <a href="{% url opts|admin_urlname:'add' menu_content.pk %}" class="addlink">

--- a/djangocms_navigation/templates/admin/djangocms_navigation/menuitem/change_list.html
+++ b/djangocms_navigation/templates/admin/djangocms_navigation/menuitem/change_list.html
@@ -7,15 +7,6 @@
 <link rel="stylesheet" type="text/css" href="{% static 'djangocms_navigation/css/navigation_admin_overrides.css' %}"/>
 {% endblock %}
 
-{% block extrahead %}
-    {% if not treebeard_4_5 %}
-    <script src="{% url 'admin:jsi18n' %}"></script>
-    <script data-csrftoken="{{ csrf_token }}" src="{% static 'djangocms_navigation/js/navigation-tree-admin.js' %}"></script>
-    {% else %}
-    {{ block.super }}
-    {% endif %}
-{% endblock %}
-
 {% block object-tools-items %}
 <li>
     <a href="{% url opts|admin_urlname:'add' menu_content.pk %}" class="addlink">

--- a/djangocms_navigation/templates/admin/djangocms_navigation/menuitem/tree_change_list.html
+++ b/djangocms_navigation/templates/admin/djangocms_navigation/menuitem/tree_change_list.html
@@ -1,0 +1,45 @@
+{# copy from djangocms-treebeard tree_change_list.html to override media files #}
+{% extends "admin/change_list.html" %}
+{% load static admin_list admin_tree admin_urls navigation_admin_tree i18n djangocms_versioning %}
+
+{% block extrastyle %}
+    {{ block.super }}
+    <link rel="stylesheet" type="text/css" href="{% static 'treebeard/treebeard-admin.css' %}" />
+    <link rel="stylesheet" type="text/css" href="{% static 'djangocms_navigation/css/navigation_admin_overrides.css' %}"/>
+{% endblock %}
+
+{% block extrahead %}
+    {{ block.super }}
+    <script src="{% url 'admin:jsi18n' %}"></script>
+    <script data-csrftoken="{{ csrf_token }}" src="{% static 'djangocms_navigation/js/navigation-tree-admin.js' %}"></script>
+{% endblock %}
+
+{% block result_list %}
+    {% if action_form and actions_on_top and cl.full_result_count %}
+        {% admin_actions %}
+    {% endif %}
+    {% result_tree cl request %}
+    {% if action_form and actions_on_bottom and cl.full_result_count %}
+        {% admin_actions %}
+    {% endif %}
+{% endblock %}
+
+{% block object-tools-items %}
+<li>
+    <a href="{% url opts|admin_urlname:'add' menu_content.pk %}" class="addlink">
+        {% blocktrans with cl.opts.verbose_name as name %}Add  {{ name }}{% endblocktrans %}
+    </a>
+</li>
+<li>
+    <a href="{% url opts|admin_urlname:'preview' menu_content.pk %}" class="cms-btn-group">
+        {% trans "Preview" %}
+    </a>
+</li>
+{% if versioning_enabled_for_nav %}
+<li>
+    <a href="{{ menu_content|url_version_list|safe }}">
+        {% trans "Versions" %}
+    </a>
+</li>
+{% endif %}
+{% endblock %}

--- a/djangocms_navigation/templatetags/navigation_admin_tree.py
+++ b/djangocms_navigation/templatetags/navigation_admin_tree.py
@@ -5,6 +5,7 @@ from django.contrib.admin.templatetags.admin_list import (
     result_hidden_fields,
 )
 from django.templatetags.static import static
+from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
@@ -104,7 +105,7 @@ def treebeard_js():
     """
 
     js_file = static('djangocms_navigation/js/navigation-tree-admin.js')
-
+    jsi18n_url = reverse('admin:jsi18n')
     jquery_ui = static('treebeard/jquery-ui-1.8.5.custom.min.js')
 
     # Jquery UI is needed to call disableSelection() on drag and drop so
@@ -118,7 +119,7 @@ def treebeard_js():
         '</script>'
         '<script type="text/javascript" src="{}"></script>')
     return format_html(
-        TEMPLATE, "jsi18n", mark_safe(js_file), mark_safe(jquery_ui))
+        TEMPLATE, jsi18n_url, mark_safe(js_file), mark_safe(jquery_ui))
 
 
 admin_tree.treebeard_js = treebeard_js

--- a/tests/requirements/dj32_cms40.txt
+++ b/tests/requirements/dj32_cms40.txt
@@ -1,3 +1,4 @@
 -r ./requirements_base.txt
 
 Django>=3.2,<4.0
+django-treebeard<=4.5.1

--- a/tests/requirements/dj42_cms40.txt
+++ b/tests/requirements/dj42_cms40.txt
@@ -1,3 +1,4 @@
 -r ./requirements_base.txt
 
 Django>=4.2,<5.0
+django-treebeard>4.6.0

--- a/tests/requirements/dj42_cms40.txt
+++ b/tests/requirements/dj42_cms40.txt
@@ -1,4 +1,4 @@
 -r ./requirements_base.txt
 
 Django>=4.2,<5.0
-django-treebeard>4.6.0
+django-treebeard>=4.6.0

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -43,9 +43,8 @@ def run():
     from app_helper import runner
     runner.cms("djangocms_navigation", extra_args=[])
     from cms.test_utils.testcases import CMSTestCase
-
-    from djangocms_navigation.compat import DJANGO_4_2
-    if not DJANGO_4_2:
+    from cms.utils.compat import DJANGO_4_1
+    if DJANGO_4_1:
         CMSTestCase.assertQuerySetEqual = CMSTestCase.assertQuerysetEqual
 
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -16,6 +16,7 @@ from django.utils.translation import gettext_lazy as _
 from cms.api import add_plugin, create_page, create_title
 from cms.test_utils.testcases import CMSTestCase
 from cms.toolbar.utils import get_object_preview_url
+from cms.utils.compat import DJANGO_4_1
 
 from bs4 import BeautifulSoup
 from djangocms_versioning.constants import DRAFT, PUBLISHED, UNPUBLISHED
@@ -28,7 +29,6 @@ from djangocms_navigation.admin import (
     MenuItemAdmin,
     MenuItemChangeList,
 )
-from djangocms_navigation.compat import DJANGO_4_2
 from djangocms_navigation.models import Menu, MenuContent, MenuItem
 from djangocms_navigation.test_utils import factories
 
@@ -65,7 +65,7 @@ class MenuItemChangelistTestCase(CMSTestCase):
             model_admin,  # model_admin
             admin_field,  # sortable_by
         ]
-        if DJANGO_4_2:
+        if not DJANGO_4_1:
             search_help_text = model_admin.search_help_text
             args.append(search_help_text)
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -2,6 +2,7 @@ import html
 import importlib
 import json
 import sys
+from unittest import skipIf, skipUnless
 from unittest.mock import patch
 
 from django.contrib import admin
@@ -29,6 +30,7 @@ from djangocms_navigation.admin import (
     MenuItemAdmin,
     MenuItemChangeList,
 )
+from djangocms_navigation.compat import TREEBEARD_4_5
 from djangocms_navigation.models import Menu, MenuContent, MenuItem
 from djangocms_navigation.test_utils import factories
 
@@ -330,6 +332,18 @@ class MenuItemModelAdminTestCase(CMSTestCase):
             ['__str__', 'get_object_url', 'soft_root', 'hide_node', "list_actions"]
         )
 
+    @skipIf(TREEBEARD_4_5, "Test relevant only for treebeard>=4.6")
+    def test_get_changelist_template(self):
+        """
+        Check the template is the standard change list template when the request is for the changelist endpoint
+        """
+        request = self.get_request("/admin/djangocms_navigation/menuitem/1/")
+
+        result = self.model_admin.get_changelist_template(request=request)
+
+        self.assertEqual(result, "admin/djangocms_navigation/menuitem/tree_change_list.html")
+
+    @skipUnless(TREEBEARD_4_5, "Test relevant only for treebeard<4.6")
     def test_get_changelist_template(self):
         """
         Check the template is the standard change list template when the request is for the changelist endpoint

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -333,7 +333,7 @@ class MenuItemModelAdminTestCase(CMSTestCase):
         )
 
     @skipIf(TREEBEARD_4_5, "Test relevant only for treebeard>=4.6")
-    def test_get_changelist_template(self):
+    def test_get_changelist_template_for_old_treebeard(self):
         """
         Check the template is the standard change list template when the request is for the changelist endpoint
         """
@@ -344,7 +344,7 @@ class MenuItemModelAdminTestCase(CMSTestCase):
         self.assertEqual(result, "admin/djangocms_navigation/menuitem/tree_change_list.html")
 
     @skipUnless(TREEBEARD_4_5, "Test relevant only for treebeard<4.6")
-    def test_get_changelist_template(self):
+    def test_get_changelist_template_for_new_treebeard(self):
         """
         Check the template is the standard change list template when the request is for the changelist endpoint
         """

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -3,9 +3,9 @@ from django.contrib.contenttypes.models import ContentType
 
 from cms.models import Page
 from cms.test_utils.testcases import CMSTestCase
+from cms.utils.compat import DJANGO_4_1
 from cms.utils.urlutils import admin_reverse
 
-from djangocms_navigation.compat import DJANGO_4_2
 from djangocms_navigation.constants import SELECT2_CONTENT_OBJECT_URL_NAME
 from djangocms_navigation.forms import (
     ContentTypeObjectSelectWidget,
@@ -17,7 +17,7 @@ from djangocms_navigation.test_utils.app_2.models import TestModel3, TestModel4
 from djangocms_navigation.test_utils.polls.models import PollContent
 
 
-if not DJANGO_4_2:
+if DJANGO_4_1:
     CMSTestCase.assertQuerySetEqual = CMSTestCase.assertQuerysetEqual
 
 


### PR DESCRIPTION
Fix `test_menuitem_changelist_custom_js` error:
**django-treebeard** 4.6.0 remove `treebeard-js` templatetag, and jquery-ui dependency.

check below reference PRs:
* https://github.com/django-treebeard/django-treebeard/pull/261 
* https://github.com/FidelityInternational/djangocms-navigation/pull/102
